### PR TITLE
Update to rustdoc-types 0.23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.22.0"
+rustdoc-types = "0.23.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -4,7 +4,7 @@ use rustdoc_types::{
     Constant, DynTrait, Enum, FnDecl, Function, FunctionPointer, GenericArg, GenericArgs,
     GenericBound, GenericParamDef, GenericParamDefKind, Generics, Impl, Import, Item, ItemEnum,
     OpaqueTy, Path, PolyTrait, Static, Struct, StructKind, Term, Trait, TraitAlias, Type,
-    TypeBinding, TypeBindingKind, Typedef, Union, WherePredicate,
+    TypeAlias, TypeBinding, TypeBindingKind, Union, WherePredicate,
 };
 
 #[allow(unused_variables)]
@@ -38,7 +38,7 @@ pub fn visit_item(item: &Item, v: &mut impl Visitor) {
             visit_type(type_, v);
         }
         ItemEnum::Impl(impl_) => visit_impl(impl_, v),
-        ItemEnum::Typedef(type_def) => visit_type_def(type_def, v),
+        ItemEnum::TypeAlias(type_alias) => visit_type_alias(type_alias, v),
         ItemEnum::Union(union_) => visit_union(union_, v),
         ItemEnum::Enum(enum_) => visit_enum(enum_, v),
 
@@ -145,8 +145,8 @@ fn visit_impl(impl_: &Impl, v: &mut impl Visitor) {
     visit_type(for_, v);
 }
 
-fn visit_type_def(type_def: &Typedef, v: &mut impl Visitor) {
-    let Typedef { type_, generics } = type_def;
+fn visit_type_alias(type_alias: &TypeAlias, v: &mut impl Visitor) {
+    let TypeAlias { type_, generics } = type_alias;
     visit_type(type_, v);
     visit_generics(generics, v);
 }


### PR DESCRIPTION
`cargo-public-api-crates` now seems to fail (like https://github.com/tower-rs/tower-http/pull/400) due to the change of the scheme (https://github.com/rust-lang/rust/pull/115078). This pull request updates to `rustdoc-types` 0.23.0 to fix this problem.