### PR TITLE
Update to rustdoc-types 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60966414633fced9e2341cd3d51a329d72306367325ba3d34e7e517c3bb84f3c"
+checksum = "0b9be1bc4a0ec3445cfa2e4ba112827544890d43d68b7d1eda5359a9c09d2cd8"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7a12c7506980eaac5c9851a04e90e0062eb4417aa188a512bf7a64a1ef290f"
+checksum = "60966414633fced9e2341cd3d51a329d72306367325ba3d34e7e517c3bb84f3c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9be1bc4a0ec3445cfa2e4ba112827544890d43d68b7d1eda5359a9c09d2cd8"
+checksum = "cbe3d9a9818bcf1e08f3ce06b359260921c2271d2c650b3589a43f0fd020774a"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.30.0"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e3124c5a7883153fe3e762da9998cf36c302dbf1cc237869d297f9713e5655"
+checksum = "7fd5cb7a0c0a5a4f6bc429274fc1073d395237c83ef13d0ac728e0f95f5499ca"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df53bab0198f33fc88c110aaabdb2df2cfee4b8a72aeaf942088e12bb305142"
+checksum = "89e3124c5a7883153fe3e762da9998cf36c302dbf1cc237869d297f9713e5655"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe3d9a9818bcf1e08f3ce06b359260921c2271d2c650b3589a43f0fd020774a"
+checksum = "edcdc023d622eeec23ac48f064126eb09b69e19728308aa905bdc28b562b4319"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdc023d622eeec23ac48f064126eb09b69e19728308aa905bdc28b562b4319"
+checksum = "5df53bab0198f33fc88c110aaabdb2df2cfee4b8a72aeaf942088e12bb305142"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.23.0"
+rustdoc-types = "0.25"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.28"
+rustdoc-types = "0.29"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.26"
+rustdoc-types = "0.27"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.27"
+rustdoc-types = "0.28"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.29"
+rustdoc-types = "0.30"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.25"
+rustdoc-types = "0.26"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.1", default-features = false, features = [
 ] }
 glob = "0.3.1"
 itertools = "0.10.5"
-rustdoc-types = "0.30"
+rustdoc-types = "0.32"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 toml = "0.7.2"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::visit::{self, Visitor};
 use anyhow::Result;
-use rustdoc_types::{Crate, Id, Import, Span};
+use rustdoc_types::{Crate, Id, Span, Use};
 
 pub struct AnalyzeOutput {
     pub krate: Crate,
@@ -67,8 +67,8 @@ impl<'a> Visitor for ItemVisitor<'a> {
         self.on_id(&path.id);
     }
 
-    fn visit_import(&mut self, import: &Import) {
-        let Some(id) = &import.id else { return };
+    fn visit_use(&mut self, use_: &Use) {
+        let Some(id) = &use_.id else { return };
         self.on_id(id);
     }
 }

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -82,7 +82,7 @@ fn visit_trait(trait_: &Trait, v: &mut impl Visitor) {
     let Trait {
         is_auto: _,
         is_unsafe: _,
-        is_object_safe: _,
+        is_dyn_compatible: _,
         items: _,
         generics,
         bounds,

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code)]
 
 use rustdoc_types::{
-    Constant, DynTrait, Enum, FnDecl, Function, FunctionPointer, GenericArg, GenericArgs,
-    GenericBound, GenericParamDef, GenericParamDefKind, Generics, Impl, Import, Item, ItemEnum,
-    OpaqueTy, Path, PolyTrait, Static, Struct, StructKind, Term, Trait, TraitAlias, Type,
-    TypeAlias, TypeBinding, TypeBindingKind, Union, WherePredicate,
+    DynTrait, Enum, FnDecl, Function, FunctionPointer, GenericArg, GenericArgs, GenericBound,
+    GenericParamDef, GenericParamDefKind, Generics, Impl, Import, Item, ItemEnum, OpaqueTy, Path,
+    PolyTrait, Static, Struct, StructKind, Term, Trait, TraitAlias, Type, TypeAlias, TypeBinding,
+    TypeBindingKind, Union, WherePredicate,
 };
 
 #[allow(unused_variables)]
@@ -231,14 +231,7 @@ fn visit_where_predicate(where_predicate: &WherePredicate, v: &mut impl Visitor)
                 visit_generic_param_def(generic_param, v);
             }
         }
-        WherePredicate::RegionPredicate {
-            lifetime: _,
-            bounds,
-        } => {
-            for bound in bounds {
-                visit_generic_bound(bound, v);
-            }
-        }
+        WherePredicate::LifetimePredicate { .. } => {}
         WherePredicate::EqPredicate { lhs, rhs } => {
             visit_type(lhs, v);
             visit_term(rhs, v);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -45,7 +45,7 @@ pub fn visit_item(item: &Item, v: &mut impl Visitor) {
         ItemEnum::Trait(trait_) => visit_trait(trait_, v),
         ItemEnum::TraitAlias(trait_alias) => visit_trait_alias(trait_alias, v),
         ItemEnum::OpaqueTy(opaque_type) => visit_opaque_type(opaque_type, v),
-        ItemEnum::Constant(constant) => visit_constant(constant, v),
+        ItemEnum::Constant { type_, const_: _ } => visit_type(type_, v),
         ItemEnum::Static(static_) => visit_static(static_, v),
         ItemEnum::Import(import) => {
             v.visit_import(import);
@@ -286,7 +286,7 @@ fn visit_generic_bound(bound: &GenericBound, v: &mut impl Visitor) {
 fn visit_term(term: &Term, v: &mut impl Visitor) {
     match term {
         Term::Type(type_) => visit_type(type_, v),
-        Term::Constant(constant) => visit_constant(constant, v),
+        Term::Constant(_) => {}
     }
 }
 
@@ -348,19 +348,9 @@ fn visit_generic_arg(arg: &GenericArg, v: &mut impl Visitor) {
     match arg {
         GenericArg::Lifetime(_) => {}
         GenericArg::Type(type_) => visit_type(type_, v),
-        GenericArg::Const(constant) => visit_constant(constant, v),
+        GenericArg::Const(_) => {}
         GenericArg::Infer => {}
     }
-}
-
-fn visit_constant(constant: &Constant, v: &mut impl Visitor) {
-    let Constant {
-        type_,
-        expr: _,
-        value: _,
-        is_literal: _,
-    } = constant;
-    visit_type(type_, v);
 }
 
 fn visit_type(type_: &Type, v: &mut impl Visitor) {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -273,6 +273,7 @@ fn visit_generic_bound(bound: &GenericBound, v: &mut impl Visitor) {
             }
         }
         GenericBound::Outlives(_) => {}
+        GenericBound::Use(_) => {}
     }
 }
 

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -91,6 +91,7 @@ fn visit_trait(trait_: &Trait, v: &mut impl Visitor) {
     let Trait {
         is_auto: _,
         is_unsafe: _,
+        is_object_safe: _,
         items: _,
         generics,
         bounds,
@@ -376,6 +377,10 @@ fn visit_type(type_: &Type, v: &mut impl Visitor) {
         }
         Type::Slice(type_) => visit_type(type_, v),
         Type::Array { type_, len: _ } => visit_type(type_, v),
+        Type::Pat {
+            type_,
+            __pat_unstable_do_not_use: _,
+        } => visit_type(type_, v),
         Type::ImplTrait(bounds) => {
             for bound in bounds {
                 visit_generic_bound(bound, v);

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -2,8 +2,8 @@
 
 use rustdoc_types::{
     DynTrait, Enum, FnDecl, Function, FunctionPointer, GenericArg, GenericArgs, GenericBound,
-    GenericParamDef, GenericParamDefKind, Generics, Impl, Import, Item, ItemEnum, OpaqueTy, Path,
-    PolyTrait, Static, Struct, StructKind, Term, Trait, TraitAlias, Type, TypeAlias, TypeBinding,
+    GenericParamDef, GenericParamDefKind, Generics, Impl, Import, Item, ItemEnum, Path, PolyTrait,
+    Static, Struct, StructKind, Term, Trait, TraitAlias, Type, TypeAlias, TypeBinding,
     TypeBindingKind, Union, WherePredicate,
 };
 
@@ -44,7 +44,6 @@ pub fn visit_item(item: &Item, v: &mut impl Visitor) {
 
         ItemEnum::Trait(trait_) => visit_trait(trait_, v),
         ItemEnum::TraitAlias(trait_alias) => visit_trait_alias(trait_alias, v),
-        ItemEnum::OpaqueTy(opaque_type) => visit_opaque_type(opaque_type, v),
         ItemEnum::Constant { type_, const_: _ } => visit_type(type_, v),
         ItemEnum::Static(static_) => visit_static(static_, v),
         ItemEnum::Import(import) => {
@@ -69,14 +68,6 @@ fn visit_static(static_: &Static, v: &mut impl Visitor) {
         expr: _,
     } = static_;
     visit_type(type_, v);
-}
-
-fn visit_opaque_type(opaque_type: &OpaqueTy, v: &mut impl Visitor) {
-    let OpaqueTy { bounds, generics } = opaque_type;
-    for bound in bounds {
-        visit_generic_bound(bound, v);
-    }
-    visit_generics(generics, v);
 }
 
 fn visit_trait_alias(trait_alias: &TraitAlias, v: &mut impl Visitor) {


### PR DESCRIPTION
This pull request updates to `rustdoc-types` 0.32 to use latest nightly rust.

`fn visit_constant` is unneeded because type is removed from `Constant` 
https://github.com/rust-lang/rust/pull/125958/commits/432c11feb6ddfffe6d1d111624ac86386b2fe751

 `WherePredicate::RegionPredicate` was renamed to `WherePredicate::LifetimePredicate` and it has only lifetime info.
https://github.com/rust-lang/rust/pull/127289